### PR TITLE
sync-fork: Grant the default token repo contents write access

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -4,11 +4,12 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
     - name: start sync
       run: gh repo sync devopsdays-london/devopsdays-web
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
- Then we don't need to keep a bot account hanging around.
- https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
- I'll test this shortly with a `workflow_dispatch` job run on this branch.